### PR TITLE
Rename requirements.pip -> requirements.txt

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -1,0 +1,33 @@
+## What does this PR do?
+
+_(required) Describe the effects of your pull request in detail. If multiple
+changes are involved, a bulleted list is often useful._
+
+## Why is this change being made?
+
+_(required) Describe the reasoning and background context for your
+change. Include a link to relevant ticket(s)._
+
+## How was this tested? How can the reviewer verify your testing?
+
+_(required) Describe the steps you used to test your change. Provide evidence of
+testing or explicit, repeatable instructions the reviewer can follow
+to verify your testing._
+
+## What gif best describes this PR or how it makes you feel?
+
+_(encouraged) Insert an appropriate gif/meme to brighten up your reviewer's day._
+
+## Completion checklist
+
+- [ ] The pull request has been appropriately labeled according to
+  our [conventions](https://kruxdigital.jira.com/wiki/display/EN/Changes+and+Peer+Review)
+- [ ] The version number has been updated.
+- [ ] The change has unit & integration tests as appropriate.
+- [ ] Documentation has been updated.
+- [ ] Dependencies have been documented, deployed, and verified as
+      appropriate.
+- [ ] Stakeholders have been notified. Workflow-impacting changes have
+      been appropriately socialized to avoid surprises.
+- [ ] Large or high-impact changes have been canaried in the
+      appropriate environment(s).

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,3 @@
-# Krux' python repo
---extra-index-url https://staticfiles.krxd.net/foss/pypi/
-
 ### The scheduler
 APScheduler==2.1.2
 
@@ -19,9 +16,6 @@ krux-stdlib==0.8.0
 ### Every time the version of krux-stdlib is updated, the list
 ### below should be updated as well.
 
-# Krux' python repo
---extra-index-url https://staticfiles.krxd.net/foss/pypi/
-
 # sphinx (for API documentation)
 Sphinx==1.2b1
 # needed by sphinx
@@ -31,7 +25,7 @@ Pygments==1.6
 docutils==0.10
 
 # stats
-kruxstatsd==0.2.2
+kruxstatsd==0.3.6
 statsd==2.0.3
 
 # Latest tested versions

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ import os
 
 
 # We use the version to construct the DOWNLOAD_URL.
-VERSION      = '0.0.2'
+VERSION      = '0.0.3'
 
 # URL to the repository on Github.
 REPO_URL     = 'https://github.com/krux/python-krux-scheduler'


### PR DESCRIPTION
## What does this PR do?
* Touches code that hasn’t been touched in over five years 😬 
* Renames `requirements.pip` to `requirements.txt`.
* Updates `kruxstatsd` version; the old one was incompatible with modern `pip`.
* Adds this PR template

## Why is this change being made?
[W-6530307](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07B00000070ucqIAA/view) Make Python repos support GitHub library dependency scans

## How was this tested? How can the reviewer verify your testing?
`python -m krux_scheduler.__init__ --log-level debug`

## What gif best describes this PR or how it makes you feel?
<img width="121" alt="Screen Shot 2019-09-19 at 11 40 02" src="https://user-images.githubusercontent.com/496931/65271627-668cc680-dad2-11e9-937d-567d0d629949.png">

## Completion checklist
- [x] The pull request has been appropriately labeled according to
  our [conventions](https://kruxdigital.jira.com/wiki/display/EN/Changes+and+Peer+Review)
- [x] The version number has been updated.
- [x] The change has unit & integration tests as appropriate.
- [x] Documentation has been updated.
- [x] Dependencies have been documented, deployed, and verified as
      appropriate.
- [x] Stakeholders have been notified. Workflow-impacting changes have
      been appropriately socialized to avoid surprises.
- [x] Large or high-impact changes have been canaried in the
      appropriate environment(s).